### PR TITLE
Set default encoding  of ont files to utf-8

### DIFF
--- a/onto.py
+++ b/onto.py
@@ -18,13 +18,14 @@ class Onto:
         self.data = data
 
     @classmethod
-    def load_from_file(cls, filename):
+    def load_from_file(cls, filename, encoding="utf-8"):
         '''
         Create instance of Onto reading ontology form ONTOLIS file.
         @param filename - name of file.
+        @param encoding - encoding of ONTOLIS file, default utf-8
         '''
         data = None
-        with open(filename) as f:
+        with open(filename, encoding=encoding) as f:
             data = json.load(f)
         if not data:
             raise ValueError("corrupt ontology")
@@ -130,12 +131,13 @@ class Onto:
                 result.append(self.get_node_by_id(link["source_node_id"]))
         return result
 
-    def write_to_file(self, filename):
+    def write_to_file(self, filename, encoding="utf-8"):
         '''
         Write down ontology to the file.
         @param filename - name of file to write into.
+        @param encoding - encoding of ONTOLIS file, default utf-8
         '''
-        with open(filename, "w") as f:
+        with open(filename, "w", ecnoding=encoding) as f:
             json.dump(self.data, f, sort_keys = True, indent = 4, ensure_ascii = False)
 
     def first(self, array):


### PR DESCRIPTION
## Problem

ONTOLIS files (`.ont`) often contain native language. Since `encoding` option in `open` of files is not set, it uses default local encoding. Sometimes it cause error on parsing JSON like:

```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 2733: character maps to <undefined>
```

Currently there is no way to change encoding while using `Onto` module.

## Solution

Instead of using unset encoding fix `utf-8`. New encoding is added as optional parameter of corresponding functions with default `utf-8`. It allows users to set another encoding if needed.

##  BREAKING CHANGE

It's a bit of breaking changes, as it changes default behavior. But it seems there won't be a problem.

If it is a problem, we could only add  new optional parameter for encoding but remove default `utf-8` value.